### PR TITLE
fsl-base.inc: Remove redundant preferred version for libdrm

### DIFF
--- a/conf/distro/include/fsl-base.inc
+++ b/conf/distro/include/fsl-base.inc
@@ -64,8 +64,5 @@ PREFERRED_VERSION_gstreamer1.0-plugins-base = "1.14.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-good = "1.14.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-bad = "1.14.imx"
 
-# Use i.MX libdrm Version
-PREFERRED_VERSION_libdrm = "2.4.91.imx"
-
 # Enable allow-autospawn-for-root as default
 PACKAGECONFIG_append_pn-pulseaudio = " autospawn-for-root"


### PR DESCRIPTION
The preferred version for libdrm is set already in the machine
configuration.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>