### PR TITLE
conf/layer.conf: Support only warrior release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "fsl-demos"
 BBFILE_PATTERN_fsl-demos := "^${LAYERDIR}/"
 BBFILE_PRIORITY_fsl-demos = "4"
 
-LAYERSERIES_COMPAT_fsl-demos = "sumo thud"
+LAYERSERIES_COMPAT_fsl-demos = "warrior"


### PR DESCRIPTION
Drop support for sumo and thud releases. If you want to use
theses branches, use the respective platform.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>