### PR TITLE
distro/fslc-base: Change DISTRO_VERSION to 2.8

### DIFF
--- a/conf/distro/include/fslc-base.inc
+++ b/conf/distro/include/fslc-base.inc
@@ -2,7 +2,7 @@ require conf/distro/poky.conf
 
 DISTRO = "fslc-base"
 DISTRO_NAME = "FSLC Distro Base"
-DISTRO_VERSION = "2.7-snapshot-${DATE}"
+DISTRO_VERSION = "2.8-snapshot-${DATE}"
 
 SDK_VENDOR = "-fslcsdk"
 


### PR DESCRIPTION
Use Yocto Project Version from Zeus release.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>