### PR TITLE
README: use pull requests for contributing

### DIFF
--- a/README
+++ b/README
@@ -21,8 +21,17 @@ revision: HEAD
 Contributing
 ------------
 
-To contribute to this layer you should send the patches for review to
-the mailing list.
+Please submit any patches against the `meta-freescale-distro` layer by
+using the GitHub pull-request feature.  Fork the repo, make a branch,
+do the work, rebase from upstream, create the pull request.
+
+For some useful guidelines to be followed when submitting patches,
+please refer to:
+http://openembedded.org/wiki/Commit_Patch_Message_Guidelines
+
+Pull requests will be discussed within the GitHub pull-request
+infrastructure. If you want to get informed on new PRs and the
+follow-up discussions please use GitHub's notification system.
 
 Mailing list:
 
@@ -31,11 +40,3 @@ Mailing list:
 Source code:
 
     https://github.com/Freescale/meta-freescale-distro
-
-When creating a patch of the last commit, use
-
-    git format-patch -s --subject-prefix='distro][PATCH' -1
-
-To send it to the community, use
-
-    git send-email --to meta-freescale@yoctoproject.org <generated patch>


### PR DESCRIPTION
The project now expects contributions being made through
GitHub's pull-request feature. Reflect that in the README.

Text mostly taken from the README in meta-qt5.

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>