### PR TITLE
imx-gpu-sdk: drop OpenGLES 3.1 for i.MX 8M Mini

### DIFF
--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.0.2.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.0.2.bb
@@ -31,10 +31,17 @@ BACKEND = \
 
 FEATURES                  = "EGL,EarlyAccess,OpenVG"
 FEATURES_append_imxgpu2d  = ",G2D"
-FEATURES_append_imxgpu3d = ",OpenGLES2"
-FEATURES_append_mx6q     = ",OpenGLES3"
-FEATURES_append_mx6dl    = ",OpenGLES3"
-FEATURES_append_mx8       = ",OpenGLES3,OpenGLES3.1,OpenCL,OpenCL1.1,OpenCL1.2,OpenCV"
+FEATURES_append_imxgpu3d  = ",OpenGLES2"
+FEATURES_append_mx6q      = ",OpenGLES3"
+FEATURES_append_mx6dl     = ",OpenGLES3"
+
+# i.MX 8M Mini does not have a support for OpenGLES3.1, therefore the split is done
+# here to remove it from feature list. All other derivatives contains this support.
+FEATURES_append_mx8mm     = ",OpenGLES3,OpenCL,OpenCL1.1,OpenCL1.2,OpenCV"
+FEATURES_append_mx8mq     = ",OpenGLES3,OpenGLES3.1,OpenCL,OpenCL1.1,OpenCL1.2,OpenCV"
+FEATURES_append_mx8qm     = ",OpenGLES3,OpenGLES3.1,OpenCL,OpenCL1.1,OpenCL1.2,OpenCV"
+FEATURES_append_mx8x      = ",OpenGLES3,OpenGLES3.1,OpenCL,OpenCL1.1,OpenCL1.2,OpenCV"
+
 FEATURES_append_mx8       = \
     "${@bb.utils.contains('DISTRO_FEATURES', 'wayland',        '', \
         bb.utils.contains('DISTRO_FEATURES',     'x11',        '', \


### PR DESCRIPTION
OpenGLES 3.1 is not supported on i.MX 8M Mini, therefore SDK build fails.

This commit splits SDK features to be built based on Machine overrides,
with exclusion of OpenGLES 3.1 for mx8mm. All other machines are explicitly
listed in the recipe with OpenGLES 3.1 support included.

Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>