### PR TITLE
packagegroup-fsl-tools-benchmark: extend cpuburn-neon with cortexa53 …

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-benchmark.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-benchmark.bb
@@ -17,5 +17,7 @@ RDEPENDS_${PN} = " \
     iperf3 \
     nbench-byte \
     tiobench \
-    ${@bb.utils.contains('TUNE_FEATURES', 'neon', 'cpuburn-neon', '', d)} \
+    ${@bb.utils.contains('TUNE_FEATURES', 'neon',             'cpuburn-neon', \
+       bb.utils.contains('TUNE_FEATURES', 'cortexa53 crypto', 'cpuburn-neon', \
+                                                              '', d), d)} \
 "


### PR DESCRIPTION
…tune

cpuburn-neon recipe contained only the 'neon' flag chack in TUNE_FEATURES,
which is not set for cortexa53 machine since it is based on aarch64.

Therefore, this recipe was never included into the aarch64-based builds,
since feature check was always returning false, effectively excluding
the cpuburn-neon from inclusion to the benchmarking package group.

This change introduces additional feature flag check, where a combination
of 'cortexa53' and 'crypto' flags should be set. Crypto extension validation
is required for Cortex-A53 since when it is enabled - the vectorization
support is also enabled in the toolchain and cpuburn-neon could be assembled.

This commit also relies on the cpuburn-neon recipe commit which splits the
build for Cortex-A53 and ARMv7, and currently is submitted to the [meta-oe],
see the upstream status link below.

Upstream-Status: Accepted [https://git.openembedded.org/meta-openembedded/commit/?id=fad26cc14e09f901ccf27db4459a4049cb6ad7ed]

Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>