### PR TITLE
distro/systemd: use pool.ntp.org with timesyncd

### DIFF
--- a/recipes-core/systemd/systemd/timesyncd.conf
+++ b/recipes-core/systemd/systemd/timesyncd.conf
@@ -1,0 +1,17 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See timesyncd.conf(5) for details.
+
+[Time]
+NTP=0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
+FallbackNTP=time1.google.com time2.google.com time3.google.com time4.google.com
+

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://timesyncd.conf"
+
+do_install_append() {
+    install -m 0644 ${WORKDIR}/timesyncd.conf ${D}${sysconfdir}/systemd
+}


### PR DESCRIPTION
Currently `timesyncd.conf` tries to access Google's ntp servers and
occasionally servers fail to respond.

I've move Google's servers to Fallback and added ntp.org's primary pool
servers as high priority instead.