### PR TITLE
i.mx8m nano machine support in distro layer

### DIFF
--- a/conf/distro/include/fsl-base.inc
+++ b/conf/distro/include/fsl-base.inc
@@ -22,6 +22,7 @@ PREFERRED_PROVIDER_u-boot_mx7d = "u-boot-imx"
 PREFERRED_PROVIDER_u-boot_mx7ulp = "u-boot-imx"
 PREFERRED_PROVIDER_u-boot_mx8mq = "u-boot-imx"
 PREFERRED_PROVIDER_u-boot_mx8mm = "u-boot-imx"
+PREFERRED_PROVIDER_u-boot_mx8mn = "u-boot-imx"
 
 # Use fsl configuration instead of fslc configuration
 MACHINEOVERRIDES_prepend = "use-fsl-bsp:"
@@ -36,6 +37,7 @@ PREFERRED_PROVIDER_virtual/bootloader_mx7d = "u-boot-imx"
 PREFERRED_PROVIDER_virtual/bootloader_mx7ulp = "u-boot-imx"
 PREFERRED_PROVIDER_virtual/bootloader_mx8mq = "u-boot-imx"
 PREFERRED_PROVIDER_virtual/bootloader_mx8mm = "u-boot-imx"
+PREFERRED_PROVIDER_virtual/bootloader_mx8mn = "u-boot-imx"
 
 PREFERRED_PROVIDER_virtual/kernel_mx6dl = "linux-imx"
 PREFERRED_PROVIDER_virtual/kernel_mx6q = "linux-imx"
@@ -47,6 +49,7 @@ PREFERRED_PROVIDER_virtual/kernel_mx7d = "linux-imx"
 PREFERRED_PROVIDER_virtual/kernel_mx7ulp = "linux-imx"
 PREFERRED_PROVIDER_virtual/kernel_mx8mq = "linux-imx"
 PREFERRED_PROVIDER_virtual/kernel_mx8mm = "linux-imx"
+PREFERRED_PROVIDER_virtual/kernel_mx8mn = "linux-imx"
 
 MACHINE_GSTREAMER_1_0_PLUGIN_mx6dl = "imx-gst1.0-plugin"
 MACHINE_GSTREAMER_1_0_PLUGIN_mx6q = "imx-gst1.0-plugin"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.0.2.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.0.2.bb
@@ -38,6 +38,7 @@ FEATURES_append_mx6dl     = ",OpenGLES3"
 # i.MX 8M Mini does not have a support for OpenGLES3.1, therefore the split is done
 # here to remove it from feature list. All other derivatives contains this support.
 FEATURES_append_mx8mm     = ",OpenGLES3,OpenCL,OpenCL1.1,OpenCL1.2,OpenCV"
+FEATURES_append_mx8mn     = ",OpenGLES3,OpenGLES3.1,OpenCL,OpenCL1.1,OpenCL1.2,OpenCV"
 FEATURES_append_mx8mq     = ",OpenGLES3,OpenGLES3.1,OpenCL,OpenCL1.1,OpenCL1.2,OpenCV"
 FEATURES_append_mx8qm     = ",OpenGLES3,OpenGLES3.1,OpenCL,OpenCL1.1,OpenCL1.2,OpenCV"
 FEATURES_append_mx8x      = ",OpenGLES3,OpenGLES3.1,OpenCL,OpenCL1.1,OpenCL1.2,OpenCV"


### PR DESCRIPTION
This follows up the [PR #254](https://github.com/Freescale/meta-freescale/pull/254) in _meta-freescale_ layer, which introduces the machine configuration for i.MX8M Nano SoC and corresponding EVK.