### PR TITLE
packagegroup-fsl-tools-gpu-external: drop eglinfo-x11

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu-external.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu-external.bb
@@ -12,7 +12,6 @@ inherit packagegroup
 
 SOC_TOOLS_GPU_X11 = ""
 SOC_TOOLS_GPU_X11_imxgpu2d = " mesa-demos glmark2 gtkperf"
-SOC_TOOLS_GPU_X11_append_imxgpu3d = " eglinfo-x11"
 
 SOC_TOOLS_GPU_FB = ""
 SOC_TOOLS_GPU_FB_imxgpu3d  = "eglinfo-fb"


### PR DESCRIPTION
It was removed upstream in commit:

http://cgit.openembedded.org/openembedded-core/commit/meta/recipes-graphics?h=zeus&id=aa36510ebea93c1f6f327152e5aa63beccad0275

Signed-off-by: Mirza Krak <mirza@maneoz.tech>