### PR TITLE
packagegroup-fsl-tools-testapps: upgrade python depends to python3

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-testapps.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-testapps.bb
@@ -25,9 +25,9 @@ RDEPENDS_${PN} = " \
     i2c-tools \
     iproute2 \
     memtester \
-    python-subprocess \
-    python-datetime \
-    python-json \
+    python3-core \
+    python3-datetime \
+    python3-json \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'v4l-utils', '', d)} \
     ethtool \
     mtd-utils \


### PR DESCRIPTION
I am actually not sure who the users of these modules are, so I have not really done any runtime tests on this.

If you have any pointers, I would gladly test it on a target as well.