### PR TITLE
packagegroup-fsl-tools-testapps: update to python3

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-testapps.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-testapps.bb
@@ -25,9 +25,9 @@ RDEPENDS_${PN} = " \
     i2c-tools \
     iproute2 \
     memtester \
-    python-subprocess \
-    python-datetime \
-    python-json \
+    python3-core \
+    python3-json \
+    python3-datetime \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'v4l-utils', '', d)} \
     ethtool \
     mtd-utils \


### PR DESCRIPTION
Update packagegroup RDEPENDS to point python3 packages, python2 has been
dropped from OE-Core since it approached EOL.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>