### PR TITLE
packagegroup-fsl-tools-gpu: remove dropped package reference

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu.bb
@@ -22,7 +22,6 @@ SOC_TOOLS_GPU_imxgpu2d = " \
 
 SOC_TOOLS_GPU_append_imxgpu3d = " \
     imx-gpu-apitrace \
-    imx-gpu-apitrace-bin \
 "
 
 RDEPENDS_${PN} = " \


### PR DESCRIPTION
Commit [189229d0f822d62c6e4da19a367f754b0c9162af] in meta-freescale
layer consolidated both libraries and binaries packages for
imx-gpu-apitrace recipe into a singe package.

Drop the reference to -bin package in the package group as it is
reported as missing and would be provided by imx-gpu-apitrace anyway.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>