### PR TITLE
imx-gpu-sdk: Fix build dependency on glslang

### DIFF
--- a/recipes-graphics/glslang/glslang_git.bb
+++ b/recipes-graphics/glslang/glslang_git.bb
@@ -1,0 +1,22 @@
+SUMMARY = "An OpenGL and OpenGL ES shader front end and validator."
+DESCRIPTION = "Glslang is the official reference compiler front end \
+               for the OpenGL ES and OpenGL shading languages. It \
+               implements a strict interpretation of the specifications \
+               for these languages. It is open and free for anyone to use, \
+               either from a command line or programmatically."
+SECTION = "graphics"
+HOMEPAGE = "https://www.khronos.org/opengles/sdk/tools/Reference-Compiler"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE.txt;beginline=22;endline=62;md5=36be65b9171c641a6c9a007bb0ba7b90 \
+    file://LICENSE.txt;beginline=62;endline=108;md5=d6589da7fd36ed28016a697e610c41bd \
+"
+
+PV = "8.13.3743+git${SRCPV}"
+SRC_URI = "git://github.com/KhronosGroup/glslang"
+SRCREV = "bcf6a2430e99e8fc24f9f266e99316905e6d5134"
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.5.3.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.5.3.bb
@@ -9,6 +9,7 @@ DEPENDS_BACKEND = \
                                                                 '', d), d)}"
 DEPENDS_MX8       = ""
 DEPENDS_MX8_mx8   = " \
+    glslang-native \
     rapidopencl \
     rapidopenvx \
     rapidvulkan \


### PR DESCRIPTION
The vulkan support depends on glslang, so add a new recipe
and a dependency.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>