### PR TITLE
.conf: Make layer compatible only with dunfell and gatesgarth

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "freescale-distro"
 BBFILE_PATTERN_freescale-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-distro = "4"
 
-LAYERSERIES_COMPAT_freescale-distro = "zeus dunfell"
+LAYERSERIES_COMPAT_freescale-distro = "dunfell gatesgarth"


### PR DESCRIPTION
Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>