### PR TITLE
Upgrade imx-gpu-sdk to 5.6.1, aligned with NXP 5.4.47-2.2.0

### DIFF
--- a/recipes-devtools/stb/stb_git.bb
+++ b/recipes-devtools/stb/stb_git.bb
@@ -15,3 +15,6 @@ do_install() {
         install -m 0644 $hdr ${D}${includedir}
     done
 }
+
+# This is a header-only library, so the main package will be empty.
+ALLOW_EMPTY_${PN} = "1"

--- a/recipes-graphics/gli/gli_0.8.2.0.bb
+++ b/recipes-graphics/gli/gli_0.8.2.0.bb
@@ -18,7 +18,7 @@ S = "${WORKDIR}/git"
 
 inherit cmake
 
-FILES_${PN}-dev += "${libdir}/cmake"
-RDEPENDS_${PN}-dev = ""
+# This is a header-only library, so the main package will be empty.
+ALLOW_EMPTY_${PN} = "1"
 
 BBCLASSEXTEND = "native"

--- a/recipes-graphics/glm/glm_%.bbappend
+++ b/recipes-graphics/glm/glm_%.bbappend
@@ -1,0 +1,2 @@
+# This is a header-only library, so the main package will be empty.
+ALLOW_EMPTY_${PN} = "1"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.6.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.6.1.bb
@@ -28,6 +28,7 @@ DEPENDS = " \
     gstreamer1.0-plugins-base \
     gtest \
     half \
+    ninja-native \
     rapidjson \
     stb \
     zlib \
@@ -40,7 +41,7 @@ DEPENDS_append_imxgpu3d = " virtual/libgles2"
 GPU_SDK_SRC ?= "git://github.com/nxpmicro/gtec-demo-framework.git;protocol=https"
 GPU_SDK_SRC_BRANCH ?= "master"
 SRC_URI = "${GPU_SDK_SRC};branch=${GPU_SDK_SRC_BRANCH}"
-SRCREV = "81da0a88e8310181814d88be4a2513220d487ca2"
+SRCREV = "42a8ae8042bfdb96c70ff399c2852c3a0650fe1b"
 
 S = "${WORKDIR}/git"
 
@@ -57,7 +58,7 @@ FEATURES_append           = "${FEATURES_SOC}"
 FEATURES_SOC       = ""
 FEATURES_SOC_mx6q  = ",OpenGLES3"
 FEATURES_SOC_mx6dl = ",OpenGLES3"
-FEATURES_SOC_mx8   = ",OpenCV,Vulkan,OpenGLES3,OpenGLES3.1,OpenCL,OpenCL1.1,OpenCL1.2,OpenVX,OpenVX1.1"
+FEATURES_SOC_mx8   = ",OpenCV,Vulkan,OpenGLES3.2,OpenCL1.2,OpenVX1.1"
 FEATURES_SOC_mx8mm = ",OpenCV"
 
 EXTENSIONS       = "*"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.6.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.6.1.bb
@@ -105,10 +105,31 @@ FILES_${PN} += "/opt/${PN}"
 FILES_${PN}-dbg += "/opt/${PN}/*/*/.debug /usr/src/debug"
 INSANE_SKIP_${PN} += "already-stripped rpaths"
 
+# Unfortunately recipes with an empty main package, like header-only libraries,
+# are not included in the SDK. Use RDEPENDS as a workaround.
+# NOTE: rapidvulkan also has an empty main package, but it is added through
+# RDEPENDS_VULKAN since we need to exclude it from 8M Mini.
+RDEPENDS_EMPTY_MAIN_PACKAGE = " \
+    fmt \
+    gli \
+    glm \
+    googletest \
+    half \
+    rapidjson \
+    stb \
+"
+RDEPENDS_EMPTY_MAIN_PACKAGE_append_mx8 = " \
+    rapidopencl \
+    rapidopenvx \
+"
 RDEPENDS_VULKAN       = ""
-RDEPENDS_VULKAN_mx8   = "vulkan-loader"
+RDEPENDS_VULKAN_mx8   = "vulkan-loader rapidvulkan"
 RDEPENDS_VULKAN_mx8mm = ""
-RDEPENDS_${PN} += "${RDEPENDS_VULKAN} googletest"
+
+RDEPENDS_${PN} += " \
+    ${RDEPENDS_EMPTY_MAIN_PACKAGE} \
+    ${RDEPENDS_VULKAN} \
+"
 
 # For backwards compatibility
 RPROVIDES_${PN} = "fsl-gpu-sdk"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.6.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.6.1.bb
@@ -50,7 +50,7 @@ BACKEND = \
         bb.utils.contains('DISTRO_FEATURES',     'x11',     'X11', \
                                                              'FB', d), d)}"
 
-FEATURES                  = "EGL,EarlyAccess,OpenVG"
+FEATURES                  = "EarlyAccess,EGL,GoogleUnitTest,OpenVG"
 FEATURES_append_imxgpu2d  = ",G2D"
 FEATURES_append_imxgpu3d  = ",OpenGLES2"
 FEATURES_append           = "${FEATURES_SOC}"


### PR DESCRIPTION
Requires https://github.com/Freescale/meta-freescale/pull/532.