### PR TITLE
fsl-base.inc: Add vulkan-loader to image explicitly

### DIFF
--- a/conf/distro/include/fsl-base.inc
+++ b/conf/distro/include/fsl-base.inc
@@ -80,3 +80,7 @@ PREFERRED_VERSION_gstreamer1.0-plugins-bad = "1.16.imx"
 
 # Enable allow-autospawn-for-root as default
 PACKAGECONFIG_append_pn-pulseaudio = " autospawn-for-root"
+
+# Vulkan loader libraries are dynamically loaded and so must be added
+# to the rootfs explicitly
+DISTRO_EXTRA_RRECOMMENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan-loader', '', d)}"


### PR DESCRIPTION
The vulkan-loader library is dynamically loaded, so bitbake won't add it
to the image implicitly, and a missing library error at runtime is the result.

Add the library explicitly based on the distro feature.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>