### PR TITLE
imx-gpu-sdk: Remove incorrect 8M Mini runtime dependencies

### DIFF
--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.6.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_5.6.1.bb
@@ -107,8 +107,6 @@ INSANE_SKIP_${PN} += "already-stripped rpaths"
 
 # Unfortunately recipes with an empty main package, like header-only libraries,
 # are not included in the SDK. Use RDEPENDS as a workaround.
-# NOTE: rapidvulkan also has an empty main package, but it is added through
-# RDEPENDS_VULKAN since we need to exclude it from 8M Mini.
 RDEPENDS_EMPTY_MAIN_PACKAGE = " \
     fmt \
     gli \
@@ -118,17 +116,22 @@ RDEPENDS_EMPTY_MAIN_PACKAGE = " \
     rapidjson \
     stb \
 "
-RDEPENDS_EMPTY_MAIN_PACKAGE_append_mx8 = " \
+RDEPENDS_EMPTY_MAIN_PACKAGE_MX8       = ""
+RDEPENDS_EMPTY_MAIN_PACKAGE_MX8_mx8   = " \
     rapidopencl \
     rapidopenvx \
+    rapidvulkan \
 "
-RDEPENDS_VULKAN       = ""
-RDEPENDS_VULKAN_mx8   = "vulkan-loader rapidvulkan"
-RDEPENDS_VULKAN_mx8mm = ""
-
+RDEPENDS_EMPTY_MAIN_PACKAGE_MX8_mx8mm = ""
+# vulkan-loader is dynamically loaded, so need to add an explicit
+# dependency
+RDEPENDS_VULKAN_LOADER       = ""
+RDEPENDS_VULKAN_LOADER_mx8   = "vulkan-loader"
+RDEPENDS_VULKAN_LOADER_mx8mm = ""
 RDEPENDS_${PN} += " \
     ${RDEPENDS_EMPTY_MAIN_PACKAGE} \
-    ${RDEPENDS_VULKAN} \
+    ${RDEPENDS_EMPTY_MAIN_PACKAGE_MX8} \
+    ${RDEPENDS_VULKAN_LOADER} \
 "
 
 # For backwards compatibility


### PR DESCRIPTION
The 8M Mini configuration does not include rapidopencl or rapidopenvx,
so remove the incorrect runtime dependencies.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>