### PR TITLE
fsl-base.inc: Adjust u-boot overrides

### DIFF
--- a/conf/distro/include/fsl-base.inc
+++ b/conf/distro/include/fsl-base.inc
@@ -33,11 +33,6 @@ PREFERRED_PROVIDER_virtual/bootloader_mx6ull = "u-boot-imx"
 PREFERRED_PROVIDER_virtual/bootloader_mx7d = "u-boot-imx"
 PREFERRED_PROVIDER_virtual/bootloader_mx7ulp = "u-boot-imx"
 PREFERRED_PROVIDER_virtual/bootloader_mx8 = "u-boot-imx"
-# u-boot-imx does not use a SPL, override machine configs
-UBOOT_MAKE_TARGET ?= "u-boot.imx"
-UBOOT_SUFFIX ?= "imx"
-SPL_BINARY ?= ""
-WKS_FILE ?= "imx-uboot-bootpart.wks.in"
 
 PREFERRED_PROVIDER_virtual/kernel_mx6dl = "linux-imx"
 PREFERRED_PROVIDER_virtual/kernel_mx6q = "linux-imx"

--- a/conf/distro/include/fsl-base.inc
+++ b/conf/distro/include/fsl-base.inc
@@ -10,30 +10,12 @@ TARGET_VENDOR = "-fsl"
 
 DISTROOVERRIDES = "fsl"
 
-# Use NXP BSP for default
+# Use NXP BSP and u-boot for default
 IMX_DEFAULT_BSP = "nxp"
+IMX_DEFAULT_BOOTLOADER = "u-boot-imx"
 
 # The following set the providers to components supported by NXP
-# Use i.MX Kernel, U-Boot and Gstreamer 1.0 providers
-PREFERRED_PROVIDER_u-boot_mx6dl = "u-boot-imx"
-PREFERRED_PROVIDER_u-boot_mx6q = "u-boot-imx"
-PREFERRED_PROVIDER_u-boot_mx6sl = "u-boot-imx"
-PREFERRED_PROVIDER_u-boot_mx6sx = "u-boot-imx"
-PREFERRED_PROVIDER_u-boot_mx6ul = "u-boot-imx"
-PREFERRED_PROVIDER_u-boot_mx6ull = "u-boot-imx"
-PREFERRED_PROVIDER_u-boot_mx7d = "u-boot-imx"
-PREFERRED_PROVIDER_u-boot_mx7ulp = "u-boot-imx"
-PREFERRED_PROVIDER_u-boot_mx8 = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader_mx6dl = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader_mx6q = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader_mx6sl = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader_mx6sx = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader_mx6ul = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader_mx6ull = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader_mx7d = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader_mx7ulp = "u-boot-imx"
-PREFERRED_PROVIDER_virtual/bootloader_mx8 = "u-boot-imx"
-
+# Use i.MX Kernel and Gstreamer 1.0 providers
 PREFERRED_PROVIDER_virtual/kernel_mx6dl = "linux-imx"
 PREFERRED_PROVIDER_virtual/kernel_mx6q = "linux-imx"
 PREFERRED_PROVIDER_virtual/kernel_mx6sl = "linux-imx"


### PR DESCRIPTION
The conditional u-boot overrides for the NXP distro are effectively
no-ops since the machine config that they are meant to override takes
precedence. Restore them to unconditional since the intent is to allow
the distro config to override the machine config. This fixes the build
error for imx6qdlsabresd:

```
| install: cannot stat '/opt/work/upstream/fsl-xwayland/tmp/work/imx6qdlsabresd-fsl-linux-gnueabi/u-boot-imx/2020.04-r0/build/u-boot.img': No such file or directory
```

The overrides were made conditional because the SPL_BINARY override is
not correct for i.MX 8M machines. This is because the SPL_BINARY
override is in fact meant for i.MX 6 and 7 only, which is how it was
applied in the original override in meta-freescale before it was moved
to meta-freescale-distro.

Fixes: 880dbf2 ("fsl-base.inc: use conditional assignment for base variables")
Fixes: e83f54d ("machines: imx-base.inc: fix failing u-boot builds")
Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>