### PR TITLE
devil: correct license file to match upstream

### DIFF
--- a/recipes-graphics/devil/devil_1.8.0.bb
+++ b/recipes-graphics/devil/devil_1.8.0.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "A full featured cross-platform image library"
 SECTION = "libs"
 LICENSE = "LGPL-2.1"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/LGPL-2.1;md5=1a6d268fd218675ffea8be556788b780"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/LGPL-2.1-only;md5=1a6d268fd218675ffea8be556788b780"
 PR = "r0"
 
 DEPENDS = "libpng jpeg tiff xz"


### PR DESCRIPTION
Upstream commit 2456f523cf ("licenses: Update license file to match current SPDX names") deprecated the usage of LGPL-2.1 SPDX identifier, removed LGPL-2.1 license file and replaced it with LGPL-2.1-only SPDX identifier and text file.

Adjust recipe to use new SDPX identifier and text file.

-- andrey