### PR TITLE
gli: backport upstream patches to resolve gcc11 build

### DIFF
--- a/recipes-graphics/gli/gli/0001-Fix-ordered-comparison-of-pointer-and-zero.patch
+++ b/recipes-graphics/gli/gli/0001-Fix-ordered-comparison-of-pointer-and-zero.patch
@@ -1,0 +1,26 @@
+From 4ea121f3a2af89e39d6fe703c9040ad254d816b2 Mon Sep 17 00:00:00 2001
+From: "Peter Hille (png!das-system)" <peter@das-system-networks.de>
+Date: Tue, 28 Aug 2018 15:34:05 +0200
+Subject: [PATCH] Fix ordered comparison of pointer and zero
+
+Upstream-Status: Backport [https://github.com/g-truc/gli/commit/4ea121f3a2af89e39d6fe703c9040ad254d816b2]
+---
+ test/core/core_convert.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/core/core_convert.cpp b/test/core/core_convert.cpp
+index 7a4366c6..38297186 100644
+--- a/test/core/core_convert.cpp
++++ b/test/core/core_convert.cpp
+@@ -33,7 +33,7 @@ bool convert_rgb32f_rgb9e5(const char* FilenameSrc, const char* FilenameDst)
+ {
+ 	if(FilenameDst == NULL)
+ 		return false;
+-	if(std::strstr(FilenameDst, ".dds") > 0 || std::strstr(FilenameDst, ".ktx") > 0)
++	if(std::strstr(FilenameDst, ".dds") != nullptr || std::strstr(FilenameDst, ".ktx") != nullptr)
+ 		return false;
+ 
+ 	gli::texture2d TextureSource(gli::load(FilenameSrc));
+-- 
+2.17.1
+

--- a/recipes-graphics/gli/gli_0.8.2.0.bb
+++ b/recipes-graphics/gli/gli_0.8.2.0.bb
@@ -12,6 +12,7 @@ LIC_FILES_CHKSUM = "file://readme.md;beginline=19;endline=20;md5=ab03b667ee630c1
 SRC_URI = " \
     git://github.com/g-truc/gli;branch=0.8.2 \
     file://0001-Set-C-standard-through-CMake-standard-options.patch \
+    file://0001-Fix-ordered-comparison-of-pointer-and-zero.patch \
 "
 SRCREV = "30808550a20ca53a255e6e1e77070493eda7b736"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
According to the GCC11 Porting Guide [1], error is issued on ordered pointer comparison with integer which causes the following build failure:

```
| test/core/core_convert.cpp:35:85: error: ordered comparison of pointer with integer zero ('const char*' and 'int')
|    35 |         if(std::strstr(FilenameDst, ".dds") > 0 || std::strstr(FilenameDst, ".ktx") > 0)
|       |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
```

Backport upstream patch to correct the ordered comparison.

Link: [1] https://gcc.gnu.org/gcc-11/porting_to.html
