### PR TITLE
Remove Clutter examples package

### DIFF
--- a/recipes-fsl/images/fsl-image-multimedia.bb
+++ b/recipes-fsl/images/fsl-image-multimedia.bb
@@ -18,13 +18,13 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     packagegroup-imx-tools-audio \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', \
                          'weston weston-init weston-examples \
-                          gtk+3-demo clutter-1.0-examples', '', d)} \
+                          gtk+3-demo', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', \
                          'weston-xwayland xterm', '', d)} \
 "
 
 PACKAGE_IMX_TO_REMOVE = ""
-PACKAGE_IMX_TO_REMOVE_imxgpu2d = "clutter-1.0-examples gtk+3-demo"
+PACKAGE_IMX_TO_REMOVE_imxgpu2d = "gtk+3-demo"
 PACKAGE_IMX_TO_REMOVE_imxgpu3d = ""
 
 CORE_IMAGE_EXTRA_INSTALL_remove = "${PACKAGE_IMX_TO_REMOVE}"

--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-testapps.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-testapps.bb
@@ -35,14 +35,11 @@ RDEPENDS_${PN} = " \
     mtd-utils-ubifs \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'gtk+3-demo', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', \
-                         'weston-examples clutter-1.0-examples', '', d)} \
+                         'weston-examples', '', d)} \
     ${SOC_TOOLS_TEST} \
 "
 
-# FIXME: i.MX6SL cannot use mesa for Graphics and it lacks GL support,
-#        so for now we skip it.
 RDEPENDS_IMX_TO_REMOVE = ""
-RDEPENDS_IMX_TO_REMOVE_imxgpu2d = "clutter-1.0-examples"
 RDEPENDS_IMX_TO_REMOVE_imxgpu3d = ""
 
 RDEPENDS_${PN}_remove = "${RDEPENDS_IMX_TO_REMOVE}"


### PR DESCRIPTION
_Clutter_ and _COGL_ recipes were dropped by OE-Core with commit [c4f167d05f5  ("Remove Clutter and Cogl")](http://git.openembedded.org/openembedded-core/commit/?id=c4f167d05f58f35a6b94e8dbc4721ab67e7e71eb).

Remove references to `clutter-1.0-examples` from `RDEPENDS` and `CORE_IMAGE_EXTRA_INSTALL`.

-- andrey