### PR TITLE
fsl-base.inc: Set linux-imx-mfgtool as preferred provider

### DIFF
--- a/conf/distro/include/fsl-base.inc
+++ b/conf/distro/include/fsl-base.inc
@@ -26,6 +26,8 @@ PREFERRED_PROVIDER_virtual/kernel_mx7d = "linux-imx"
 PREFERRED_PROVIDER_virtual/kernel_mx7ulp = "linux-imx"
 PREFERRED_PROVIDER_virtual/kernel_mx8 = "linux-imx"
 
+PREFERRED_PROVIDER_linux-imx-mfgtool = "linux-imx-mfgtool"
+
 MACHINE_GSTREAMER_1_0_PLUGIN_mx6dl = "imx-gst1.0-plugin"
 MACHINE_GSTREAMER_1_0_PLUGIN_mx6q = "imx-gst1.0-plugin"
 MACHINE_GSTREAMER_1_0_PLUGIN_mx6sl = "imx-gst1.0-plugin"


### PR DESCRIPTION
Prevent multiple providers:

```
ERROR: Multiple .bb files are due to be built which each provide linux-mfgtool:
  /opt/work/upstream/sources/meta-freescale/recipes-kernel/linux/linux-imx-mfgtool_5.10.bb
  /opt/work/upstream/sources/meta-freescale/recipes-kernel/linux/linux-fslc-lts-mfgtool_5.10.bb
```

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>