### PR TITLE
fsl-image-machine-test: Add firmwared

### DIFF
--- a/recipes-fsl/images/fsl-image-machine-test.bb
+++ b/recipes-fsl/images/fsl-image-machine-test.bb
@@ -22,6 +22,8 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     packagegroup-fsl-tools-gpu-external \
     packagegroup-fsl-tools-testapps \
     packagegroup-fsl-tools-benchmark \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', \
+                         'firmwared', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', \
                          'weston weston-init', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', \


### PR DESCRIPTION
1. Firmware loading failure occurs for regulatory.db:

[    3.616070] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
[    3.624709] platform regulatory.0: Falling back to sysfs fallback for: regulatory.db
[   64.473750] cfg80211: failed to load regulatory.db

2. Firmware loading failure occurs for imx-sdma if set to builtin:

[   64.474069] imx-sdma 20ec000.sdma: Direct firmware load for imx/sdma/sdma-imx6q.bin failed with error -2
[   64.496589] imx-sdma 20ec000.sdma: Falling back to sysfs fallback for: imx/sdma/sdma-imx6q.bin</div>
[  125.913831] imx-sdma 20ec000.sdma: external firmware not found, using ROM firmware

Add firmwared to the image to provide firmware loading for the
firmware fallback mechanism.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>