### PR TITLE
packagegroup-fsl-tools-gpu: exclude broken imx-gpu-apitrace

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu.bb
@@ -18,10 +18,6 @@ SOC_TOOLS_GPU:imxgpu2d = " \
                                                        '', d), d)} \
 "
 
-SOC_TOOLS_GPU:append:imxgpu3d = " \
-    imx-gpu-apitrace \
-"
-
 SOC_TOOLS_GPU:append:imxgpu = " \
     imx-gpu-sdk \
     imx-gpu-viv-tools \


### PR DESCRIPTION
This is a follow-up for https://github.com/Freescale/meta-freescale/pull/844, which excludes the currently broken `imx-gpu-apitrace` package from package group until it is updated to be compatible with newer glibc.

-- andrey