### PR TITLE
Revert "packagegroup-fsl-tools-gpu: exclude broken imx-gpu-apitrace"

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-gpu.bb
@@ -18,6 +18,10 @@ SOC_TOOLS_GPU:imxgpu2d = " \
                                                        '', d), d)} \
 "
 
+SOC_TOOLS_GPU:append:imxgpu3d = " \
+    imx-gpu-apitrace \
+"
+
 SOC_TOOLS_GPU:append:imxgpu = " \
     imx-gpu-sdk \
     imx-gpu-viv-tools \


### PR DESCRIPTION
imx-gpu-apitrace package has additional patch and can be build with `glibc >= 2.34`

This reverts commit 92c75c69e2edd834f9a5c3f47115805e45e28608.

This PR is linked with https://github.com/Freescale/meta-freescale/pull/857

Cc: @thochstein 