### PR TITLE
conf: distro: use proper syntax to define init system

### DIFF
--- a/conf/distro/fsl-wayland.conf
+++ b/conf/distro/fsl-wayland.conf
@@ -5,8 +5,9 @@ require conf/distro/include/fsl-base.inc
 DISTRO = "fsl-wayland"
 DISTRO_NAME = "FSL Wayland"
 
+# Define Init System
+INIT_MANAGER = "systemd"
+
 # Remove conflicting backends
 DISTRO_FEATURES:remove = "directfb x11"
-DISTRO_FEATURES:append = " wayland pam systemd"
-VIRTUAL-RUNTIME_init_manager = "systemd"
-DISTRO_FEATURES_BACKFILL_CONSIDERED:append = " sysvinit"
+DISTRO_FEATURES:append = " wayland pam"

--- a/conf/distro/fsl-xwayland.conf
+++ b/conf/distro/fsl-xwayland.conf
@@ -5,8 +5,9 @@ require conf/distro/include/fsl-base.inc
 DISTRO = "fsl-xwayland"
 DISTRO_NAME = "FSL Wayland with XWayland"
 
+# Define Init System
+INIT_MANAGER = "systemd"
+
 # Remove conflicting backends
 DISTRO_FEATURES:remove = "directfb"
-DISTRO_FEATURES:append = " x11 wayland pam systemd"
-VIRTUAL-RUNTIME_init_manager = "systemd"
-DISTRO_FEATURES_BACKFILL_CONSIDERED:append = " sysvinit"
+DISTRO_FEATURES:append = " x11 wayland pam"

--- a/conf/distro/fslc-wayland.conf
+++ b/conf/distro/fslc-wayland.conf
@@ -5,8 +5,9 @@ require conf/distro/include/fslc-base.inc
 DISTRO = "fslc-wayland"
 DISTRO_NAME = "FSLC Wayland"
 
+# Define Init System
+INIT_MANAGER = "systemd"
+
 # Remove conflicting backends
 DISTRO_FEATURES:remove = "directfb x11"
-DISTRO_FEATURES:append = " wayland pam systemd"
-VIRTUAL-RUNTIME_init_manager = "systemd"
-DISTRO_FEATURES_BACKFILL_CONSIDERED:append = " sysvinit"
+DISTRO_FEATURES:append = " wayland pam"

--- a/conf/distro/fslc-xwayland.conf
+++ b/conf/distro/fslc-xwayland.conf
@@ -5,8 +5,9 @@ require conf/distro/include/fslc-base.inc
 DISTRO = "fslc-xwayland"
 DISTRO_NAME = "FSLC Wayland with XWayland"
 
+# Define Init System
+INIT_MANAGER = "systemd"
+
 # Remove conflicting backends
 DISTRO_FEATURES:remove = "directfb"
-DISTRO_FEATURES:append = " x11 wayland pam systemd"
-VIRTUAL-RUNTIME_init_manager = "systemd"
-DISTRO_FEATURES_BACKFILL_CONSIDERED:append = " sysvinit"
+DISTRO_FEATURES:append = " x11 wayland pam"


### PR DESCRIPTION
Since OE-Core commit 8d0b4704a5 ("defaultsetup.conf: enable select init manager"), init manager setting is moved to a separate variable and simplified.

[Yocto documentation](https://docs.yoctoproject.org/singleindex.html#init-system-selection) suggests that the new syntax should be used to define init manager in distro definitions.

Convert all syntax to use new init system selection.
