### PR TITLE
fsl-image-multimedia: conditionally add weston to IMAGE_FEATURES

### DIFF
--- a/recipes-fsl/images/fsl-image-multimedia.bb
+++ b/recipes-fsl/images/fsl-image-multimedia.bb
@@ -3,7 +3,7 @@ Freescale's multimedia packages (VPU and GPU) when available for the specific \
 machine."
 
 IMAGE_FEATURES += "\
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '', \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'weston', \
        bb.utils.contains('DISTRO_FEATURES',     'x11', 'x11-base', \
                                                        '', d), d)} \
 "


### PR DESCRIPTION
This will cause the SYSTEMD_DEFAULT_TARGET to be set to graphical.target (rootfs-postcommands.bbclass), which is needed otherwise weston does not start on boot.