### PR TITLE
weston-init: Set XDG_RUNTIME_DIR manually

### DIFF
--- a/conf/distro/include/fslc-base.inc
+++ b/conf/distro/include/fslc-base.inc
@@ -32,11 +32,11 @@ def arm_tune_handler(d):
         tune = d.getVar('DEFAULTTUNE', True)
     return tune
 
-DEFAULTTUNE_fslc := "${@arm_tune_handler(d)}"
+DEFAULTTUNE:fslc := "${@arm_tune_handler(d)}"
 
 DISTRO_ARM_INSTRUCTION ?= "thumb"
 DISTRO_ARM_INSTRUCTION:armv5 ?= "arm"
-ARM_INSTRUCTION_SET_fslc ??= "${DISTRO_ARM_INSTRUCTION}"
+ARM_INSTRUCTION_SET:fslc ??= "${DISTRO_ARM_INSTRUCTION}"
 
 PACKAGECONFIG:remove:pn-xserver-xorg:armv5 = "dri"
 

--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://profile"
+
+do_install:append() {
+    if [ "${@bb.utils.filter('DISTROOVERRIDES', 'fsl fslc', d)}" != "" ]; then
+        install -Dm0755 ${WORKDIR}/profile ${D}${sysconfdir}/profile.d/weston.sh
+    fi
+}

--- a/recipes-graphics/wayland/weston-init/profile
+++ b/recipes-graphics/wayland/weston-init/profile
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Set XDG_RUNTIME_DIR manually.
+# The variable is not set for ssh login, causing app failures. It's not clear
+# if this is an error or by design, but setting it manually does help and
+# doesn't seem to hurt...
+if test -z "$XDG_RUNTIME_DIR"; then
+	export XDG_RUNTIME_DIR=/run/user/`id -u`
+fi


### PR DESCRIPTION
The variable is not set for ssh or console, causing app failures. It's
not clear if this is an error or by design, but setting it manually
does help and doesn't seem to hurt.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>

See https://github.com/Freescale/meta-freescale/pull/858