### PR TITLE
weston-init: Set XDG_RUNTIME_DIR manually

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://profile"
+
+do_install:append() {
+    if [ "${@bb.utils.filter('DISTROOVERRIDES', 'fsl fslc', d)}" != "" ]; then
+        install -Dm0755 ${WORKDIR}/profile ${D}${sysconfdir}/profile.d/weston.sh
+    fi
+}

--- a/recipes-graphics/wayland/weston-init/profile
+++ b/recipes-graphics/wayland/weston-init/profile
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Set XDG_RUNTIME_DIR manually.
+# The variable is not set for ssh login, causing app failures. It's not clear
+# if this is an error or by design, but setting it manually does help and
+# doesn't seem to hurt...
+if test -z "$XDG_RUNTIME_DIR"; then
+	export XDG_RUNTIME_DIR=/run/user/`id -u`
+fi


### PR DESCRIPTION
The variable is not set for ssh or console, causing app failures. It's
not clear if this is an error or by design, but setting it manually
does help and doesn't seem to hurt.

Set for fsl and fslc distros.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
(cherry picked from commit ff0076e26dc03f3b06d5df32befa7d22b341d857)