### PR TITLE
assimp: Replace failing patch

### DIFF
--- a/recipes-graphics/vulkan/assimp_5.0.1.bb
+++ b/recipes-graphics/vulkan/assimp_5.0.1.bb
@@ -12,7 +12,6 @@ SRC_URI = "git://github.com/assimp/assimp.git;branch=assimp_5.0_release \
            file://0001-closes-https-github.com-assimp-assimp-issues-2733-up.patch \
            file://use-GNUInstallDirs-where-possible.patch \
            file://0001-assimp-remove-shared-lib-from-_IMPORT_CHECK_TARGETS.patch \
-           file://0001-Make-BSD-compliant.patch \
            "
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>(\d+(\.\d+)+))"
 
@@ -21,6 +20,16 @@ SRCREV = "8f0c6b04b2257a520aaab38421b2e090204b69df"
 S = "${WORKDIR}/git"
 
 inherit cmake
+
+do_unpack:append() {
+    bb.build.exec_func('remove_non_compliant_source', d)
+}
+
+remove_non_compliant_source() {
+    # Remove non-compliant files manually. A patch file cannot be used
+    # since many of the files are binary.
+    rm -rf ${S}/test/models-nonbsd ${S}/scripts/StepImporter/schema_ifc2x3.exp
+}
 
 EXTRA_OECMAKE = "-DASSIMP_BUILD_ASSIMP_TOOLS=OFF -DASSIMP_BUILD_TESTS=OFF -DASSIMP_LIB_INSTALL_DIR=${baselib}"
 


### PR DESCRIPTION
The patch to remove non-compliant source fails due to the existence of
binaries.

Drop the patch and instead remove the non-compliant source manually
from do_unpack.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>

Fixes #72 