### PR TITLE
layer: set missing branch and protocol for recipes using git

### DIFF
--- a/recipes-devtools/stb/stb_git.bb
+++ b/recipes-devtools/stb/stb_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://stb.h;beginline=14418;endline=14433;md5=b10975d4c8155
 PV = "0.0+git${SRCPV}"
 
 SRCREV = "f67165c2bb2af3060ecae7d20d6f731173485ad0"
-SRC_URI = "git://github.com/nothings/stb.git"
+SRC_URI = "git://github.com/nothings/stb.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-graphics/glslang/glslang_git.bb
+++ b/recipes-graphics/glslang/glslang_git.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "\
 "
 
 PV = "8.13.3743+git${SRCPV}"
-SRC_URI = "git://github.com/KhronosGroup/glslang"
+SRC_URI = "git://github.com/KhronosGroup/glslang;protocol=https;branch=master"
 SRCREV = "bcf6a2430e99e8fc24f9f266e99316905e6d5134"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Recent Bitbake update introduced following commits in attempt to adapt to [new requirement from GitHub](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git):
```
86a9c268 ("fetch2/git: Add a warning asking users to set a branch in git urls")
42526a40 ("fetch/git: Show warning for invalid github urls")
```
There is a warning issued for those recipes that either do not explicitly provide branch parameter to the Bitbake fetcher, or still
using unauthenticated git:// protocol.

Adapt recipes across layer to accommodate for those new requirements.

-- andrey
