### PR TITLE
weston-init: Increase watchdog timeout

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -7,3 +7,16 @@ do_install:append() {
         install -Dm0755 ${WORKDIR}/profile ${D}${sysconfdir}/profile.d/weston.sh
     fi
 }
+
+WATCHDOG_SEC = "40"
+WATCHDOG_SEC:mx8ulp = "240"
+replace_setting() {
+    if ! grep -q "$1" $3; then
+        bbwarn "Setting to replace '$1' not found in file $3"
+    fi
+    sed -i -e "s,$1,$2," $3
+}
+# NOTE: This is for fsl distro only
+do_install:append:fsl() {
+    replace_setting "WatchdogSec=.*" "WatchdogSec=${WATCHDOG_SEC}" ${D}${systemd_system_unitdir}/weston.service
+}


### PR DESCRIPTION
The watchdog timeout is shortened to 20s, a bit too short for us [1].
Increase it to prevent un-necessary watchdog failures.

[1] https://lists.openembedded.org/g/openembedded-core/message/155193

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>