### PR TITLE
recipes-graphics: correct fetch links using github

### DIFF
--- a/recipes-graphics/gli/gli_0.8.4.0.bb
+++ b/recipes-graphics/gli/gli_0.8.4.0.bb
@@ -10,7 +10,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://readme.md;beginline=19;endline=20;md5=ab03b667ee630c1abb1add70365a50fb"
 
 SRC_URI = " \
-    git://github.com/g-truc/gli \
+    git://github.com/g-truc/gli;protocol=https;branch=master \
 "
 SRCREV = "0c171ee87fcfe35a7e0e0445adef06f92e0b6a91"
 S = "${WORKDIR}/git"

--- a/recipes-graphics/rapidopencl/rapidopencl_1.1.0.1.bb
+++ b/recipes-graphics/rapidopencl/rapidopencl_1.1.0.1.bb
@@ -2,7 +2,7 @@ SUMMARY = "Experimental low level header only C++11 RAII wrapper classes for the
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b98f636daed34d12d11e25f3185c0204"
 
-SRC_URI = "git://github.com/Unarmed1000/RapidOpenCL;protocol=https \
+SRC_URI = "git://github.com/Unarmed1000/RapidOpenCL;protocol=https;branch=master \
 "
 SRCREV = "21254804a56ae96e8385c2652733c338d62da04f"
 

--- a/recipes-graphics/rapidopenvx/rapidopenvx_1.1.0.bb
+++ b/recipes-graphics/rapidopenvx/rapidopenvx_1.1.0.bb
@@ -2,7 +2,7 @@ SUMMARY = "Low level header only C++11 RAII wrapper classes for the OpenVX API"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b98f636daed34d12d11e25f3185c0204"
 
-SRC_URI = "git://github.com/Unarmed1000/RapidOpenVX;protocol=https \
+SRC_URI = "git://github.com/Unarmed1000/RapidOpenVX;protocol=https;branch=master \
 "
 SRCREV = "909c7abbff0ee35610f07f6fadeaf3a2eadce36e"
 

--- a/recipes-graphics/rapidvulkan/rapidvulkan_1.2.162.0.bb
+++ b/recipes-graphics/rapidvulkan/rapidvulkan_1.2.162.0.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b98f636daed34d12d11e25f3185c0204"
 
 DEPENDS = "vulkan-loader"
 
-SRC_URI = "git://github.com/Unarmed1000/RapidVulkan;protocol=https"
+SRC_URI = "git://github.com/Unarmed1000/RapidVulkan;protocol=https;branch=master"
 SRCREV = "e39a407c5ae880792d8843ada65a19dd26b3dca7"
 
 S = "${WORKDIR}/git"

--- a/recipes-graphics/vulkan/assimp_5.0.1.bb
+++ b/recipes-graphics/vulkan/assimp_5.0.1.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2119edef0916b0bd511cb3c731076271"
 
 DEPENDS = "zlib"
 
-SRC_URI = "git://github.com/assimp/assimp.git;branch=assimp_5.0_release \
+SRC_URI = "git://github.com/assimp/assimp.git;protocol=https;branch=assimp_5.0_release \
            file://0001-closes-https-github.com-assimp-assimp-issues-2733-up.patch \
            file://use-GNUInstallDirs-where-possible.patch \
            file://0001-assimp-remove-shared-lib-from-_IMPORT_CHECK_TARGETS.patch \


### PR DESCRIPTION
This fixes warnings from Bitbake, which were introduced to adhere to [GitHub requirements](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git)
