### PR TITLE
fslc-base.inc: Allow override of BUILDHISTORY_COMMIT

### DIFF
--- a/conf/distro/include/fslc-base.inc
+++ b/conf/distro/include/fslc-base.inc
@@ -42,7 +42,7 @@ PACKAGECONFIG:remove:pn-xserver-xorg:armv5 = "dri"
 
 # Log information on images and packages
 INHERIT += "buildhistory"
-BUILDHISTORY_COMMIT = "1"
+BUILDHISTORY_COMMIT ?= "1"
 
 # Use bluez5 as default.
 DISTRO_FEATURES:append = " bluez5"


### PR DESCRIPTION
The user cannot disable buildhistory from local.conf because it is set
in fslc-base.inc. Use a default setting instead.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>