### PR TITLE
layer.conf: Bump to kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "freescale-distro"
 BBFILE_PATTERN_freescale-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-distro = "4"
 
-LAYERSERIES_COMPAT_freescale-distro = "honister"
+LAYERSERIES_COMPAT_freescale-distro = "kirkstone"


### PR DESCRIPTION
It's not backward ABI compatible with honister due to variable renaming.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>