### PR TITLE
weston-init: force runtime variable to weston user

### DIFF
--- a/recipes-graphics/wayland/weston-init/profile
+++ b/recipes-graphics/wayland/weston-init/profile
@@ -1,9 +1,5 @@
 #!/bin/sh
 
 # Set XDG_RUNTIME_DIR manually.
-# The variable is not set for ssh login, causing app failures. It's not clear
-# if this is an error or by design, but setting it manually does help and
-# doesn't seem to hurt...
-if test -z "$XDG_RUNTIME_DIR"; then
-	export XDG_RUNTIME_DIR=/run/user/`id -u`
-fi
+# The variable is set for the root user which no longer is the case
+export XDG_RUNTIME_DIR=/run/user/`id weston -u`


### PR DESCRIPTION
The weston-init service has switched to weston user in poky since the
hardknott release [1].

NXP overcomes this issue by forcing the user back to root [2]. This
patch is another approach to fix the same issue, instead of reverting to
the root user, let's make sure the XDG_RUNTIME_DIR variable is _always_
set to the weston user as it otherwise defaults back to root currently.

[1] https://git.yoctoproject.org/poky/commit/?id=ccdaab97
[2] https://source.codeaurora.org/external/imx/meta-imx/commit/?id=3519f6bb

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>