### PR TITLE
Update LICENSE variable to use SPDX license identifiers

### DIFF
--- a/recipes-fsl/fsl-rc-local/fsl-rc-local.bb
+++ b/recipes-fsl/fsl-rc-local/fsl-rc-local.bb
@@ -1,7 +1,7 @@
 # Copyright (C) 2012 O.S. Systems Software LTDA.
 
 DESCRIPTION = "Extra files for fsl-gui-image"
-LICENSE = "LGPLv2"
+LICENSE = "LGPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=39ec502560ab2755c4555ee8416dfe42"
 
 SRC_URI = "file://rc.local.etc \

--- a/recipes-graphics/devil/devil_1.8.0.bb
+++ b/recipes-graphics/devil/devil_1.8.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "A full featured cross-platform image library"
 SECTION = "libs"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/LGPL-2.1-only;md5=1a6d268fd218675ffea8be556788b780"
 PR = "r0"
 

--- a/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
+++ b/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
@@ -4,7 +4,7 @@ SUMMARY = "RTSP server for live-stream from a v4l2 video source"
 HOMEPAGE = "https://github.com/Gateworks/gst-gateworks-apps"
 SECTION = "multimedia"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 
 inherit pkgconfig
 


### PR DESCRIPTION
Since OE-Core commit [`9379f80f48 ("license/insane: Show warning forobsolete license usage")`](https://github.com/openembedded/openembedded-core/commit/9379f80f484f94686a4d494e9e237fadfb72a938), `LICENSE` field not containing SPDX identifiers are treated with _WARNING_.

An automated conversion using OE-Core `scripts/contrib/convert-spdx-licenses.py` to convert to use the standard SPDX license identifiers has been done on the entire layer.
