### PR TITLE
weston-init:profile: change to set WAYLAND_DISPLAY

### DIFF
--- a/recipes-graphics/wayland/weston-init/profile
+++ b/recipes-graphics/wayland/weston-init/profile
@@ -1,9 +1,7 @@
 #!/bin/sh
 
-# Set XDG_RUNTIME_DIR manually.
-# The variable is not set for ssh login, causing app failures. It's not clear
-# if this is an error or by design, but setting it manually does help and
-# doesn't seem to hurt...
-if test -z "$XDG_RUNTIME_DIR"; then
-	export XDG_RUNTIME_DIR=/run/user/`id -u weston`
+# Set WAYLAND_DISPLAY manually.
+# It will cause app failures if this variable is not set for ssh login.
+if test -z "$WAYLAND_DISPLAY"; then
+	export WAYLAND_DISPLAY="/run/wayland-0"
 fi


### PR DESCRIPTION
Setting XDG_RUNTIME_DIR variable in profile env would not help for
log-in users except weston.

There is now a global /run/wayland-0 socket that gets created for
wayland clients to access, let's use that instead.

Reference commit in OE:
[
commit dd83fb40f76749c6689807afabc63b9d5c2a4065
Author: Joshua Watt <JPEWhacker@gmail.com>
Date:   Thu Nov 19 16:58:53 2020 -0600

    weston-init: Stop running weston as root

    Running the weston compositor as the root user is an insecure default
    behavior for OE-core. We can do much better, at least when using
    systemd. Change the recipe to create a dedicated "weston" user and start
    weston as this user. The systemd service and socket units are no longer
    template units, as there were several inconsistencies in the templates.
    Instead, there is now a global /run/wayland-0 socket that gets created,
    and systemd will start weston on demand when a client connects to that
    socket or when attempting to reach graphical.target, whichever comes
    first. This also allows downstream users to easily change the behavior
    so that weston *only* starts on demand by adding a drop file. Access to
    the global socket is controlled by a "wayland" group; any user that is a
    member of the group can use the socket to talk to the compositor. This
    also satisfies another use case where another systemd service might
    start a graphical application that needs to display with weston (e.g. a
    single function device in kiosk mode). Finally, the udev rules for
    starting weston with the existance of a DRM device have been removed.
    Being WantedBy= a graphical target should eliminate the need for this
    behavior, and having it present makes it difficult for downstream users
    to start weston on demand (having to override the udev rules).

    Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>
    Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
]

Signed-off-by: Ming Liu <liu.ming50@gmail.com>