### PR TITLE
distro:fslc-base.inc: drop bluez5 from DISTRO_FEATURES

### DIFF
--- a/conf/distro/include/fslc-base.inc
+++ b/conf/distro/include/fslc-base.inc
@@ -43,6 +43,3 @@ PACKAGECONFIG:remove:pn-xserver-xorg:armv5 = "dri"
 # Log information on images and packages
 INHERIT += "buildhistory"
 BUILDHISTORY_COMMIT ?= "1"
-
-# Use bluez5 as default.
-DISTRO_FEATURES:append = " bluez5"


### PR DESCRIPTION
Since commit dcf889e93401f7c4de0055d53271eacc3882eccc in OE: [
    meta: Remove remnants of bluez4 support

    bluez4 was removed from meta-oe 2 years ago.

    Simplfy the setup of the two level bluetooth and bluez4/bluez5
    distro features by removing the bluez4/bluez5 distro features.

    This also removes the no longer required bluetooth class.

    Signed-off-by: Adrian Bunk <bunk@stusta.de>
    Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
]

bluez5 is no longer a distro feature, and there is no reference to it neither in Freescale/OE meta layers, let's drop it.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>