### PR TITLE
fslc-base: fix setting of used instruction set

### DIFF
--- a/conf/distro/include/fslc-base.inc
+++ b/conf/distro/include/fslc-base.inc
@@ -34,10 +34,6 @@ def arm_tune_handler(d):
 
 DEFAULTTUNE:fslc := "${@arm_tune_handler(d)}"
 
-DISTRO_ARM_INSTRUCTION ?= "thumb"
-DISTRO_ARM_INSTRUCTION:armv5 ?= "arm"
-ARM_INSTRUCTION_SET:fslc ??= "${DISTRO_ARM_INSTRUCTION}"
-
 PACKAGECONFIG:remove:pn-xserver-xorg:armv5 = "dri"
 
 # Log information on images and packages


### PR DESCRIPTION
While there aren't many recipe setting the instruction set to arm anymore, the way the fslc distro sets thumb as the default is still wrong.