### PR TITLE
packagegroup-fsl-gstreamer1.0: use corrtect plugin name

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0.bb
@@ -45,8 +45,7 @@ RDEPENDS:${PN}-base = " \
     gstreamer1.0-plugins-base-audioresample \
     gstreamer1.0-plugins-base-gio \
     gstreamer1.0-plugins-base-typefindfunctions \
-    gstreamer1.0-plugins-base-videoconvert \
-    gstreamer1.0-plugins-base-videoscale \
+    gstreamer1.0-plugins-base-videoconvertscale \
     gstreamer1.0-plugins-base-volume \
     gstreamer1.0-plugins-good-autodetect \
     ${MACHINE_GSTREAMER_1_0_PLUGIN} \


### PR DESCRIPTION
According to the oe-core commit fb2d28e0315e("gstreamer1.0: update 1.20.5 -> 1.22.0"), videoconvert/videoscale plugins were merged into one. So, remove the obsolete plugin name and use the corrtect one.