### PR TITLE
imx-gpu-sdk: Upgrade 6.1.0 -> 6.1.1

### DIFF
--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk-src.inc
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk-src.inc
@@ -1,4 +1,4 @@
 SRC_URI = "${GPU_SDK_SRC};branch=${GPU_SDK_SRC_BRANCH}"
 GPU_SDK_SRC ?= "git://github.com/nxp-imx/gtec-demo-framework.git;protocol=https"
 GPU_SDK_SRC_BRANCH ?= "master"
-SRCREV = "ed8a6ac85234b0aaa28ce0035286293240a5e02c"
+SRCREV = "35bbd45ed6eac169a778bd154283771b9bf39be7"

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
@@ -51,7 +51,8 @@ WINDOW_SYSTEM = \
         bb.utils.contains('DISTRO_FEATURES',     'x11',         'X11', \
                                                                  'FB', d), d)}"
 
-FEATURES                  = "EarlyAccess,EGL,GoogleUnitTest,Lib_NlohmannJson,OpenVG"
+FEATURES                  = "ConsoleHost,EarlyAccess,EGL,GoogleUnitTest,Lib_NlohmannJson,OpenVG,Test_RequireUserInputToExit,WindowHost"
+FEATURES:append:imxgpu    = ",HW_GPU_VIVANTE"
 FEATURES:append:imxgpu2d  = ",G2D"
 FEATURES:append:imxgpu3d  = ",OpenGLES2"
 FEATURES:append           = "${FEATURES_SOC}"


### PR DESCRIPTION
Release 6.1.1
- GCC13 support.
- Small wayland bug fix.
- Vulkan.NativeWindowTest update.
- New 'feature' to make it easier to filter apps during testing.
- Scr version updated.