### PR TITLE
weston-init: Drop profile script now handled by OE-Core

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,9 +1,0 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-SRC_URI += "file://profile"
-
-do_install:append() {
-    if [ "${@bb.utils.filter('DISTROOVERRIDES', 'fsl fslc', d)}" != "" ]; then
-        install -Dm0755 ${WORKDIR}/profile ${D}${sysconfdir}/profile.d/weston.sh
-    fi
-}

--- a/recipes-graphics/wayland/weston-init/profile
+++ b/recipes-graphics/wayland/weston-init/profile
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Set WAYLAND_DISPLAY manually.
-# It will cause app failures if this variable is not set for ssh login.
-if test -z "$WAYLAND_DISPLAY"; then
-	export WAYLAND_DISPLAY="/run/wayland-0"
-fi


### PR DESCRIPTION
The profile script setting WAYLAND_DISPLAY is now handled in OE-Core and can be dropped.

https://github.com/openembedded/openembedded-core/commit/1600f38d72818cda78a4731354dbecc144f664c9

Note that our profile script was in fact correct only for the systemd case, since it's only there that Yocto sets the Wayland socket to the non-default value `/run/wayland-0`.