### PR TITLE
meta-freescale-distro: add necessary dependent layers for meta-freesc…

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,6 @@ BBFILE_COLLECTIONS += "freescale-distro"
 BBFILE_PATTERN_freescale-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-distro = "4"
 
+LAYERDEPENDS_freescale-distro = "core yocto"
+
 LAYERSERIES_COMPAT_freescale-distro = "langdale mickledore"


### PR DESCRIPTION
…ale-distro

When parsing yocto project with command "bitbake -p", there is below error reported:
layers/meta-freescale-distro/conf/distro/include/fslc-base.inc:1: Could not include required file conf/distro/poky.conf Because the necessary dependent layers of meta-freescale-distro are not downloaded when setting up project, add them to avoid building issue.