### PR TITLE
recipes: Update github.com urls to use https

### DIFF
--- a/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
+++ b/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
@@ -13,7 +13,7 @@ DEPENDS = "gstreamer1.0 gstreamer1.0-rtsp-server glib-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 SRC_URI = " \
-    git://github.com/Gateworks/gst-gateworks-apps;branch=master \
+    git://github.com/Gateworks/gst-gateworks-apps;branch=master;protocol=https \
 "
 
 SRCREV = "490564815d8049dbdd79087f546835b673ba6e88"


### PR DESCRIPTION
Github has announced there will be no more git:// fetching from their servers: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git