### PR TITLE
packagegroup-fsl-tools-testapps: Drop fsl-rc-local if no sysvinit

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-tools-testapps.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-tools-testapps.bb
@@ -21,7 +21,7 @@ RDEPENDS:${PN} = " \
     dosfstools \
     evtest \
     e2fsprogs-mke2fs \
-    fsl-rc-local \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'fsl-rc-local', '', d)} \
     fbset \
     i2c-tools \
     iproute2 \


### PR DESCRIPTION
fsl-rc-local is for sysvinit, so include it only when sysvinit is in DISTRO_FEATURES.