### PR TITLE
fslc-base: Update distro version to be based on scarthgap release

### DIFF
--- a/conf/distro/include/fslc-base.inc
+++ b/conf/distro/include/fslc-base.inc
@@ -2,7 +2,7 @@ require conf/distro/poky.conf
 
 DISTRO = "fslc-base"
 DISTRO_NAME = "FSLC Distro Base"
-DISTRO_VERSION = "4.1-snapshot-${DATE}"
+DISTRO_VERSION = "5.0"
 
 SDK_VENDOR = "-fslcsdk"
 


### PR DESCRIPTION
Update distro version to be based on scarthgap release