### PR TITLE
layer.conf: Update to styhead

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_freescale-distro = "4"
 
 LAYERDEPENDS_freescale-distro = "core yocto"
 
-LAYERSERIES_COMPAT_freescale-distro = "langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_freescale-distro = "styhead"


### PR DESCRIPTION
Drop all older release names as there have been potentially incompatible changes, e.g. the S must not point to WORKDIR.