### PR TITLE
Fix weston not starting under sysvinit

### DIFF
--- a/conf/distro/fsl-wayland.conf
+++ b/conf/distro/fsl-wayland.conf
@@ -6,7 +6,7 @@ DISTRO = "fsl-wayland"
 DISTRO_NAME = "FSL Wayland"
 
 # Define Init System
-INIT_MANAGER = "systemd"
+INIT_MANAGER = "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'sysvinit', 'systemd', d)}"
 
 # Remove conflicting backends
 DISTRO_FEATURES:remove = "directfb x11"

--- a/conf/distro/fslc-wayland.conf
+++ b/conf/distro/fslc-wayland.conf
@@ -6,7 +6,7 @@ DISTRO = "fslc-wayland"
 DISTRO_NAME = "FSLC Wayland"
 
 # Define Init System
-INIT_MANAGER = "systemd"
+INIT_MANAGER = "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'sysvinit', 'systemd', d)}"
 
 # Remove conflicting backends
 DISTRO_FEATURES:remove = "directfb x11"

--- a/recipes-fsl/images/fsl-image-machine-test.bb
+++ b/recipes-fsl/images/fsl-image-machine-test.bb
@@ -28,4 +28,6 @@ CORE_IMAGE_EXTRA_INSTALL += " \
                          'weston weston-init', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', \
                          'weston-xwayland xterm', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', \
+                         'weston-sysvinit', '', d)} \
 "

--- a/recipes-fsl/images/fsl-image-multimedia.bb
+++ b/recipes-fsl/images/fsl-image-multimedia.bb
@@ -21,6 +21,8 @@ CORE_IMAGE_EXTRA_INSTALL += " \
                           gtk+3-demo', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', \
                          'weston-xwayland xterm', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', \
+                         'weston-sysvinit', '', d)} \
 "
 
 PACKAGE_IMX_TO_REMOVE = ""


### PR DESCRIPTION
Related to #123

Modify configuration files to support sysvinit for weston.

* **conf/distro/fsl-wayland.conf**
  - Set `INIT_MANAGER` to "sysvinit" when sysvinit is used.
  - Add a conditional check for sysvinit in the `INIT_MANAGER` setting.

* **conf/distro/fslc-wayland.conf**
  - Set `INIT_MANAGER` to "sysvinit" when sysvinit is used.
  - Add a conditional check for sysvinit in the `INIT_MANAGER` setting.

* **recipes-fsl/images/fsl-image-machine-test.bb**
  - Include necessary sysvinit configurations for weston.
  - Add a conditional check for sysvinit in the `CORE_IMAGE_EXTRA_INSTALL` setting.

* **recipes-fsl/images/fsl-image-multimedia.bb**
  - Include necessary sysvinit configurations for weston.
  - Add a conditional check for sysvinit in the `CORE_IMAGE_EXTRA_INSTALL` setting.

