### PR TITLE
fsl-base.inc: Update gstreamer1.0-plugin-base/bad/good version to 1.24.7

### DIFF
--- a/conf/distro/include/fsl-base.inc
+++ b/conf/distro/include/fsl-base.inc
@@ -29,10 +29,10 @@ MACHINE_GSTREAMER_1_0_PLUGIN:mx9-nxp-bsp = "imx-gst1.0-plugin"
 PREFERRED_VERSION_ffmpeg                    = "4.4.1"
 
 # GStreamer forked recipes
-PREFERRED_VERSION_gstreamer1.0              ??= "1.24.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-bad  ??= "1.24.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-base ??= "1.24.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-good ??= "1.24.0.imx"
+PREFERRED_VERSION_gstreamer1.0              ??= "1.24.7.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-bad  ??= "1.24.7.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-base ??= "1.24.7.imx"
+PREFERRED_VERSION_gstreamer1.0-plugins-good ??= "1.24.7.imx"
 
 # GStreamer copied recipes
 PREFERRED_VERSION_gst-devtools              ??= "1.24.0.imx"


### PR DESCRIPTION
Update gstreamer version to aligin with scarthgap-6.6.52_2.2.0

1.24.0 -> 1.24.7