### PR TITLE
layer.conf: update for the whinlatter release series

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_freescale-distro = "4"
 
 LAYERDEPENDS_freescale-distro = "core yocto"
 
-LAYERSERIES_COMPAT_freescale-distro = "styhead walnascar"
+LAYERSERIES_COMPAT_freescale-distro = "walnascar whinlatter"


### PR DESCRIPTION
Fix current error:
ERROR: Layer freescale-distro is not compatible with the core layer which only supports these series: whinlatter (layer is compatible with styhead walnascar)