### PR TITLE
updates for WORKDIR/UNPACKDIR and git fetch location 

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_freescale-distro = "4"
 
 LAYERDEPENDS_freescale-distro = "core yocto"
 
-LAYERSERIES_COMPAT_freescale-distro = "walnascar whinlatter"
+LAYERSERIES_COMPAT_freescale-distro = "whinlatter"

--- a/recipes-devtools/half/half_2.1.0.bb
+++ b/recipes-devtools/half/half_2.1.0.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=813a6278831975d26c115ed6f9c21831"
 SRC_URI = "https://sourceforge.net/projects/half/files/half/${PV}/${BP}.zip"
 SRC_URI[sha256sum] = "ad1788afe0300fa2b02b0d1df128d857f021f92ccf7c8bddd07812685fa07a25"
 
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 do_install () {
     install -d ${D}${includedir}

--- a/recipes-fsl/fsl-rc-local/fsl-rc-local.bb
+++ b/recipes-fsl/fsl-rc-local/fsl-rc-local.bb
@@ -8,7 +8,7 @@ SRC_URI = "file://rc.local.etc \
            file://rc.local.init \
            file://LICENSE"
 
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 inherit update-rc.d
 


### PR DESCRIPTION
This is a not backward compatible change. Not all layers did the update as of now.
This change is needed if one updates oe-core to commit cedc4ff7c9bc ("meta: remove consecutive blank lines") or later, however not all layer will then behave as expected.
