### PR TITLE
meta-freescale-distro: Add whinlatter changes

### DIFF
--- a/recipes-devtools/stb/stb_git.bb
+++ b/recipes-devtools/stb/stb_git.bb
@@ -7,8 +7,6 @@ PV = "0.0+git${SRCPV}"
 SRCREV = "f67165c2bb2af3060ecae7d20d6f731173485ad0"
 SRC_URI = "git://github.com/nothings/stb.git;protocol=https;branch=master"
 
-S = "${WORKDIR}/git"
-
 do_install() {
     install -d ${D}${includedir}
     for hdr in ${S}/*.h; do

--- a/recipes-graphics/devil/devil_1.8.0.bb
+++ b/recipes-graphics/devil/devil_1.8.0.bb
@@ -9,7 +9,7 @@ DEPENDS = "libpng jpeg tiff xz"
 SRC_URI = "http://sourceforge.net/projects/openil/files/DevIL/${PV}/DevIL-${PV}.zip"
 SRC_URI[sha256sum] = "451337f392c65bfb83698a781370534dc63d7bafca21e9b37178df0518f7e895"
 
-S = "${WORKDIR}/DevIL/DevIL"
+S = "${UNPACKDIR}/DevIL/DevIL"
 
 inherit cmake
 

--- a/recipes-graphics/gli/gli_0.8.4.0.bb
+++ b/recipes-graphics/gli/gli_0.8.4.0.bb
@@ -13,7 +13,6 @@ SRC_URI = " \
     git://github.com/g-truc/gli;protocol=https;branch=master \
 "
 SRCREV = "0c171ee87fcfe35a7e0e0445adef06f92e0b6a91"
-S = "${WORKDIR}/git"
 
 inherit cmake
 

--- a/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
+++ b/recipes-graphics/imx-gpu-sdk/imx-gpu-sdk_6.1.1.bb
@@ -44,7 +44,6 @@ DEPENDS:append:imxgpu3d = " virtual/libgles2"
 
 require imx-gpu-sdk-src.inc
 
-S = "${WORKDIR}/git"
 
 WINDOW_SYSTEM = \
     "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Wayland_XDG', \

--- a/recipes-graphics/rapidopencl/rapidopencl_1.1.0.1.bb
+++ b/recipes-graphics/rapidopencl/rapidopencl_1.1.0.1.bb
@@ -6,8 +6,6 @@ SRC_URI = "git://github.com/Unarmed1000/RapidOpenCL;protocol=https;branch=master
 "
 SRCREV = "21254804a56ae96e8385c2652733c338d62da04f"
 
-S = "${WORKDIR}/git"
-
 # RapidOpenCL is a header-only C++11 RAII wrapper class, so the main package will be empty.
 
 do_install () {

--- a/recipes-graphics/rapidopenvx/rapidopenvx_1.1.0.bb
+++ b/recipes-graphics/rapidopenvx/rapidopenvx_1.1.0.bb
@@ -6,8 +6,6 @@ SRC_URI = "git://github.com/Unarmed1000/RapidOpenVX;protocol=https;branch=master
 "
 SRCREV = "909c7abbff0ee35610f07f6fadeaf3a2eadce36e"
 
-S = "${WORKDIR}/git"
-
 do_install () {
     install -d ${D}${includedir}
     cp -r ${S}/include/* ${D}${includedir}

--- a/recipes-graphics/rapidvulkan/rapidvulkan_1.2.162.0.bb
+++ b/recipes-graphics/rapidvulkan/rapidvulkan_1.2.162.0.bb
@@ -7,7 +7,6 @@ DEPENDS = "vulkan-loader"
 SRC_URI = "git://github.com/Unarmed1000/RapidVulkan;protocol=https;branch=master"
 SRCREV = "e39a407c5ae880792d8843ada65a19dd26b3dca7"
 
-S = "${WORKDIR}/git"
 
 inherit cmake
 

--- a/recipes-graphics/vulkan/assimp_5.0.1.bb
+++ b/recipes-graphics/vulkan/assimp_5.0.1.bb
@@ -17,7 +17,6 @@ UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>(\d+(\.\d+)+))"
 
 SRCREV = "8f0c6b04b2257a520aaab38421b2e090204b69df"
 
-S = "${WORKDIR}/git"
 
 inherit cmake
 

--- a/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
+++ b/recipes-multimedia/gstreamer/gst-variable-rtsp-server_1.0.bb
@@ -18,7 +18,6 @@ SRC_URI = " \
 
 SRCREV = "490564815d8049dbdd79087f546835b673ba6e88"
 
-S = "${WORKDIR}/git"
 
 do_install() {
     install -m 0755 -D ${S}/bin/gst-variable-rtsp-server \


### PR DESCRIPTION
do_unpack: Recipes that set S = "${WORKDIR}/git" or S = "${UNPACKDIR}/git" should remove that assignment, as S set by bitbake.conf in oe-core now works.