### PR TITLE
packagegroup-fsl-gstreamer1.0: follow meta-freescale changes to imx-gst1.0-plugin

### DIFF
--- a/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0.bb
+++ b/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0.bb
@@ -49,8 +49,7 @@ RDEPENDS:${PN}-base = " \
     gstreamer1.0-plugins-base-volume \
     gstreamer1.0-plugins-good-autodetect \
     ${MACHINE_GSTREAMER_1_0_PLUGIN} \
-    ${@bb.utils.contains("MACHINE_GSTREAMER_1_0_PLUGIN", "imx-gst1.0-plugin", "imx-gst1.0-plugin-gplay", "", d)} \
-    ${@bb.utils.contains("MACHINE_GSTREAMER_1_0_PLUGIN", "imx-gst1.0-plugin", "imx-gst1.0-plugin-grecorder", "", d)} \
+    ${@bb.utils.contains("MACHINE_GSTREAMER_1_0_PLUGIN", "imx-gst1.0-plugin", "imx-gst1.0-plugin-tools", "", d)} \
 "
 
 RRECOMMENDS:${PN}-base = " \


### PR DESCRIPTION
Commit 25c0c7d34a60 ("gst/gstreamer: Bump 1.26.0 -> 1.26.6") in meta-freescale removed the packages imx-gst1.0-plugin-gplay and imx-gst1.0-plugin-grecorder and merged them together with some other tools into imx-gst1.0-plugin-tools.

Replace these packages with imx-gst1.0-plugin-tools.

Fixes the following build error:
ERROR: Nothing RPROVIDES 'imx-gst1.0-plugin-grecorder' (but [...]/layers/meta-freescale-distro/recipes-fsl/packagegroups/packagegroup-fsl-gstreamer1.0.bb RDEPENDS on or otherwise requires it)