### PR TITLE
[RFC] conf/distro: wire distros through meta-freescale fragments

### DIFF
--- a/conf/distro/fsl-framebuffer.conf
+++ b/conf/distro/fsl-framebuffer.conf
@@ -5,5 +5,5 @@ require conf/distro/include/fsl-base.inc
 DISTRO = "fsl-framebuffer"
 DISTRO_NAME = "FSL FrameBuffer"
 
-# Remove conflicting backends.
-DISTRO_FEATURES:remove = "x11 wayland directfb vulkan "
+include conf/fragments/bsp/nxp.conf
+include conf/fragments/graphics/framebuffer.conf

--- a/conf/distro/fsl-wayland.conf
+++ b/conf/distro/fsl-wayland.conf
@@ -8,6 +8,5 @@ DISTRO_NAME = "FSL Wayland"
 # Define Init System
 INIT_MANAGER = "systemd"
 
-# Remove conflicting backends
-DISTRO_FEATURES:remove = "directfb x11"
-DISTRO_FEATURES:append = " wayland pam"
+include conf/fragments/bsp/nxp.conf
+include conf/fragments/graphics/wayland.conf

--- a/conf/distro/fsl-xwayland.conf
+++ b/conf/distro/fsl-xwayland.conf
@@ -8,6 +8,5 @@ DISTRO_NAME = "FSL Wayland with XWayland"
 # Define Init System
 INIT_MANAGER = "systemd"
 
-# Remove conflicting backends
-DISTRO_FEATURES:remove = "directfb"
-DISTRO_FEATURES:append = " x11 wayland pam"
+include conf/fragments/bsp/nxp.conf
+include conf/fragments/graphics/xwayland.conf

--- a/conf/distro/fslc-framebuffer.conf
+++ b/conf/distro/fslc-framebuffer.conf
@@ -5,5 +5,5 @@ require conf/distro/include/fslc-base.inc
 DISTRO = "fslc-framebuffer"
 DISTRO_NAME = "FSLC FrameBuffer"
 
-# Remove conflicting backends.
-DISTRO_FEATURES:remove = "x11 wayland directfb vulkan"
+include conf/fragments/bsp/fslc.conf
+include conf/fragments/graphics/framebuffer.conf

--- a/conf/distro/fslc-wayland.conf
+++ b/conf/distro/fslc-wayland.conf
@@ -8,6 +8,5 @@ DISTRO_NAME = "FSLC Wayland"
 # Define Init System
 INIT_MANAGER = "systemd"
 
-# Remove conflicting backends
-DISTRO_FEATURES:remove = "directfb x11"
-DISTRO_FEATURES:append = " wayland pam"
+include conf/fragments/bsp/fslc.conf
+include conf/fragments/graphics/wayland.conf

--- a/conf/distro/fslc-x11.conf
+++ b/conf/distro/fslc-x11.conf
@@ -5,8 +5,5 @@ require conf/distro/include/fslc-base.inc
 DISTRO = "fslc-x11"
 DISTRO_NAME = "FSLC X11"
 
-# Remove conflicting backends.
-DISTRO_FEATURES:remove = "wayland "
-
-# These are X11 specific
-DISTRO_FEATURES:append = " x11"
+include conf/fragments/bsp/fslc.conf
+include conf/fragments/graphics/x11.conf

--- a/conf/distro/fslc-xwayland.conf
+++ b/conf/distro/fslc-xwayland.conf
@@ -8,6 +8,5 @@ DISTRO_NAME = "FSLC Wayland with XWayland"
 # Define Init System
 INIT_MANAGER = "systemd"
 
-# Remove conflicting backends
-DISTRO_FEATURES:remove = "directfb"
-DISTRO_FEATURES:append = " x11 wayland pam"
+include conf/fragments/bsp/fslc.conf
+include conf/fragments/graphics/xwayland.conf

--- a/conf/distro/include/fsl-base.inc
+++ b/conf/distro/include/fsl-base.inc
@@ -9,36 +9,3 @@ MAINTAINER = "Freescale Semiconductors <lauren.post@nxp.com>"
 TARGET_VENDOR = "-fsl"
 
 DISTROOVERRIDES = "fsl"
-
-# Use NXP BSP and u-boot for default
-IMX_DEFAULT_BSP = "nxp"
-IMX_DEFAULT_BOOTLOADER = "u-boot-imx"
-
-# The following set the providers to components supported by NXP
-# Use i.MX Kernel and Gstreamer 1.0 providers
-PREFERRED_PROVIDER_virtual/kernel:mx6-nxp-bsp = "linux-imx"
-PREFERRED_PROVIDER_virtual/kernel:mx7-nxp-bsp = "linux-imx"
-PREFERRED_PROVIDER_virtual/kernel:mx8-nxp-bsp = "linux-imx"
-PREFERRED_PROVIDER_virtual/kernel:mx9-nxp-bsp = "linux-imx"
-
-MACHINE_GSTREAMER_1_0_PLUGIN:mx6-nxp-bsp = "imx-gst1.0-plugin"
-MACHINE_GSTREAMER_1_0_PLUGIN:mx7-nxp-bsp = "imx-gst1.0-plugin"
-MACHINE_GSTREAMER_1_0_PLUGIN:mx8-nxp-bsp = "imx-gst1.0-plugin"
-MACHINE_GSTREAMER_1_0_PLUGIN:mx9-nxp-bsp = "imx-gst1.0-plugin"
-
-# GStreamer forked recipes
-PREFERRED_VERSION_gstreamer1.0              ??= "1.24.7.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-bad  ??= "1.24.7.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-base ??= "1.24.7.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-good ??= "1.24.7.imx"
-
-# GStreamer copied recipes
-PREFERRED_VERSION_gst-devtools              ??= "1.24.0.imx"
-PREFERRED_VERSION_gstreamer1.0-libav        ??= "1.24.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-ugly ??= "1.24.0.imx"
-PREFERRED_VERSION_gstreamer1.0-python       ??= "1.24.0.imx"
-PREFERRED_VERSION_gstreamer1.0-rtsp-server  ??= "1.24.0.imx"
-PREFERRED_VERSION_gstreamer1.0-vaapi        ??= "1.24.0.imx"
-
-# Enable allow-autospawn-for-root as default
-PACKAGECONFIG:append:pn-pulseaudio = " autospawn-for-root"


### PR DESCRIPTION
Phase 1 of the distro-to-fragments migration: keep all existing distros intact so users are not broken, but have them source configuration from the canonical fragments in meta-freescale instead of duplicating it.

  - Each fslc-*.conf includes conf/fragments/bsp/fslc.conf (IMX_DEFAULT_BSP = mainline, linux-fslc, u-boot-fslc)
  - fsl-base.inc replaces its NXP provider/GStreamer/PulseAudio block with conf/fragments/bsp/nxp.conf
  - Each distro .conf replaces its DISTRO_FEATURES lines with the matching conf/fragments/graphics/<backend>.conf include

Behaviour is identical for existing users of DISTRO = "fslc-wayland" etc.; the change validates the fragments by driving builds through them before Phase 2 removes the distros.