### PR TITLE
layer.conf: silence BBFILE_PATTERN warning for config-only layer

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,9 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "freescale-distro"
 BBFILE_PATTERN_freescale-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-distro = "4"
+# This is a distro-configuration-only layer and ships no recipes, so tell
+# BitBake not to warn when BBFILE_PATTERN matches no bb files.
+BBFILE_PATTERN_IGNORE_EMPTY_freescale-distro = "1"
 
 LAYERDEPENDS_freescale-distro = "core yocto"
 


### PR DESCRIPTION
## What

`meta-freescale-distro` is now a distro-configuration-only layer: the recipes,
packagegroups and demo images it used to carry were moved to `meta-freescale`.
Because the layer no longer ships any `.bb` files, BitBake warns on every parse:

```
WARNING: No bb files in default matched BBFILE_PATTERN_freescale-distro
'^.../sources/meta-freescale-distro/'
```

## How

Set `BBFILE_PATTERN_IGNORE_EMPTY_freescale-distro = "1"` so BitBake accepts that
the collection legitimately matches no recipes. This is the same mechanism
OE-core uses for the `devtool` workspace layer and the `oeqa` temporary layers
(`cooker.py` only emits the warning when this variable is not `"1"`). The
collection, `BBFILE_PATTERN` and priority are kept so the layer can host a
recipe again if ever needed.

## Test

`grep` of `bitbake/lib/bb/cooker.py` confirms the warning at the
`No bb files ... matched BBFILE_PATTERN` site is guarded by
`BBFILE_PATTERN_IGNORE_EMPTY_<collection> != "1"`. (A full local `bitbake -p`
could not be run to completion in the CI sandbox used here because the host
build toolchain is unavailable, but the guard is unconditional in the parser.)

This should be backported to **wrynose**.